### PR TITLE
Fix InlineCacheKey formatters for invalid UTF-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrome-cache-parser"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "chrome-cache-parser"
 include = [
     "**/*.rs"
 ]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Chrome cache parser"

--- a/src/block_file.rs
+++ b/src/block_file.rs
@@ -70,17 +70,16 @@ pub struct InlineCacheKey {
 
 impl fmt::Debug for InlineCacheKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", std::str::from_utf8(&self.key).unwrap())
+        let key = String::from_utf8_lossy(&self.key);
+        write!(f, "{}", key.trim_end_matches(char::from(0)))
     }
 }
 
 impl fmt::Display for InlineCacheKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let key = std::str::from_utf8(&self.key)
-            .map_err(|_| fmt::Error)?
-            .trim_end_matches(char::from(0));
-        write!(f, "{}", key)?;
-        Ok(())
+        let key = String::from_utf8_lossy(&self.key);
+        let trimmed = key.trim_end_matches(char::from(0));
+        write!(f, "{}", trimmed)
     }
 }
 


### PR DESCRIPTION
Ran into a panic whenever I tried to log cache keys that weren’t valid UTF-8. Swapped InlineCacheKey’s Display/
  Debug to use `String::from_utf8_lossy` so they never return `fmt::Error`. With this in,
  `entry.key.to_string()` stays safe